### PR TITLE
Reorder ApkdPackage structure to fit what dbus returns

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -36,10 +36,10 @@ typedef struct
 {
   const gchar *m_name;
   const gchar *m_version;
-  const gchar *m_oldVersion;
-  const gchar *m_license;
-  const gchar *m_url;
   const gchar *m_description;
+  const gchar *m_license;
+  const gchar *m_oldVersion;
+  const gchar *m_url;
   gulong m_installedSize;
   gulong m_size;
   ApkPackageState m_packageState;


### PR DESCRIPTION
The fields returned by dbus where assigned to in the wrong
value order.

This seems to fix some problems with gnome-software doing weird stuff, like considering all packages for downgrade because the old version would look like `GNU Compiler Colection`.

See https://gitlab.alpinelinux.org/Cogitri/apk-polkit-rs/-/blob/master/apk-tools/src/apk_package.rs#L162