### PR TITLE
Implement new gs_plugin_*_repo functions and increase repo generalization

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -778,8 +778,8 @@ gs_plugin_add_sources (GsPlugin *plugin,
 
       value_tuple = g_variant_get_child_value (repositories, i);
       enabled = g_variant_get_boolean (g_variant_get_child_value (value_tuple, 0));
-      description = g_strdup (g_variant_get_string (g_variant_get_child_value (value_tuple, 1), &len));
-      url = g_strdup (g_variant_get_string (g_variant_get_child_value (value_tuple, 2), &len));
+      description = g_strdup (g_variant_get_string (g_variant_get_child_value (value_tuple, 1), NULL));
+      url = g_variant_get_string (g_variant_get_child_value (value_tuple, 2), NULL);
       repo_name = g_strsplit (url, "/", -1);
       len = g_strv_length (repo_name);
 

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -756,6 +756,14 @@ gs_plugin_add_sources (GsPlugin *plugin,
       description = g_strdup (g_variant_get_string (g_variant_get_child_value (value_tuple, 1), NULL));
       url = g_strdup (g_variant_get_string (g_variant_get_child_value (value_tuple, 2), NULL));
 
+      app = gs_plugin_cache_lookup (plugin, url);
+      if (app)
+        {
+          gs_app_set_state (app, enabled ? GS_APP_STATE_INSTALLED : GS_APP_STATE_AVAILABLE);
+          gs_app_list_add (list, g_steal_pointer (&app));
+          continue;
+        }
+
       g_debug ("Adding repository  %s", url);
 
       g_uri_split (url, G_URI_FLAGS_NONE, &url_scheme, NULL,
@@ -806,6 +814,7 @@ gs_plugin_add_sources (GsPlugin *plugin,
       gs_app_set_url (app, AS_URL_KIND_HOMEPAGE, url);
       gs_app_set_metadata (app, "apk::repo-url", url);
       gs_app_set_management_plugin (app, "apk");
+      gs_plugin_cache_add (plugin, url, app);
       gs_app_list_add (list, g_steal_pointer (&app));
 
       g_strfreev (repo_parts);

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -75,7 +75,8 @@ g_variant_to_apkd_package (GVariant *value_tuple)
  *
  * Convenience function which converts ApkdPackageState to a GsAppState.
  **/
-static GsAppState apk_to_app_state (ApkPackageState state)
+static GsAppState
+apk_to_app_state (ApkPackageState state)
 {
   switch (state)
     {
@@ -90,7 +91,7 @@ static GsAppState apk_to_app_state (ApkPackageState state)
     case Upgradable:
       return GS_APP_STATE_UPDATABLE_LIVE;
     default:
-      g_assert_not_reached();
+      g_assert_not_reached ();
       return GS_APP_STATE_UNKNOWN;
     }
 }
@@ -450,7 +451,7 @@ gs_plugin_update (GsPlugin *plugin,
   gs_plugin_updates_changed (plugin);
   return TRUE;
 
- error:
+error:
   g_propagate_error (error, g_steal_pointer (&local_error));
   gs_app_set_state_recover (app);
   priv->current_app = NULL;
@@ -662,7 +663,7 @@ resolve_matching_package (GsPlugin *plugin,
 
   set_app_metadata (plugin, app, &pkg, flags);
   /* We should only set generic apps for OS updates */
-  if (gs_app_get_kind(app) == AS_COMPONENT_KIND_GENERIC)
+  if (gs_app_get_kind (app) == AS_COMPONENT_KIND_GENERIC)
     gs_app_set_special_kind (app, GS_APP_SPECIAL_KIND_OS_UPDATE);
 
   return TRUE;


### PR DESCRIPTION
Helps #13 

I believe this is the last bit pending to have the same functionality in GNOME 41 that there existed in GNOME 3.38. So maybe after merging this one would be the moment for a new release?

There is one caveat to the current implementation though. Disabling a repository behaves the same as removing it. Therefore, if somebody disables a repo, closes the dialog and reopens it, the repository will not show (instead of the logical showing as disabled). This problem can be avoided not implementing the enable/disable functions. In that case the switches will be blocked, but the removal button will still exist. I do not have a clear mind here on which of the two options are better. Ideas?

The underlying reason for this problem is that (as far as I understand) apk does not really differentiate between installed/enable and removed/disabled repos. The implemenation in apk-polkit-rs is super nice in the fact that considers a disabled repo as  a repo which is commented out. Unfortunately that detail is only presented in the DBus as a read property, but there is no method to disable or enable a repository. Looking at the code, implementing it should be fairly simple, but I have no clue about rust, so I don't think I'll be able to implement such functionality soon. Anyway, I created https://gitlab.alpinelinux.org/Cogitri/apk-polkit-rs/-/issues/9 to track it.

BTW, I have tested this patch in multiple combinations, and it all looks to be working quite alright :)