### PR TITLE
Set GS_APP_PROGRESS_UNKNOWN for functions that block

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -283,6 +283,7 @@ gs_plugin_add_updates (GsPlugin *plugin,
 
   g_debug ("Adding updates");
 
+  gs_app_set_progress (repo, GS_APP_PROGRESS_UNKNOWN);
   if (!apk_polkit1_call_list_upgradable_packages_sync (priv->proxy, &upgradable_packages, cancellable, &local_error))
     {
       g_dbus_error_strip_remote_error (local_error);
@@ -325,6 +326,7 @@ gs_plugin_app_install (GsPlugin *plugin,
   if (g_strcmp0 (gs_app_get_management_plugin (app), "apk") != 0)
     return TRUE;
 
+  gs_app_set_progress (repo, GS_APP_PROGRESS_UNKNOWN);
   gs_app_set_state (app, GS_APP_STATE_INSTALLING);
 
   if (gs_app_get_kind (app) == AS_COMPONENT_KIND_REPOSITORY)
@@ -372,6 +374,7 @@ gs_plugin_app_remove (GsPlugin *plugin,
   if (g_strcmp0 (gs_app_get_management_plugin (app), "apk") != 0)
     return TRUE;
 
+  gs_app_set_progress (repo, GS_APP_PROGRESS_UNKNOWN);
   gs_app_set_state (app, GS_APP_STATE_REMOVING);
 
   if (gs_app_get_kind (app) == AS_COMPONENT_KIND_REPOSITORY)
@@ -414,6 +417,7 @@ gs_plugin_update (GsPlugin *plugin,
   GsPluginData *priv = gs_plugin_get_data (plugin);
   GsApp *app;
 
+  gs_app_set_progress (repo, GS_APP_PROGRESS_UNKNOWN);
   for (guint i = 0; i < gs_app_list_length (apps); i++)
     {
       app = gs_app_list_index (apps, i);


### PR DESCRIPTION
refine and setup are skipped because it is not specified
whether the signal should be sent and because they will
have to be reworked for GNOME 42 anyway