### PR TITLE
ci: use pull_request_target

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,5 +1,5 @@
 name: Run tests for Spracherkennung
-on: pull_request
+on: pull_request_target
 
 jobs:
   test:


### PR DESCRIPTION
This allows access to credentials for pull requests. Otherwise
the flow cannot run for contributors. See[1][2]

[1] https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
[2] https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

As mentioned in the documentation, this could be a security issue. However, if the `DOCKER_TOKEN` is only allowed read-only access to the registry, I believe there should not be any possible misuse of it (considering the Dockerfile is also public).