### PR TITLE
Fix segmentation fault for double free in repo construction

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -785,15 +785,17 @@ gs_plugin_add_sources (GsPlugin *plugin,
           /* If there is a scheme, it is a remote repository. Try to build
            * a description depending on the information available,
            * e.g: ["alpine", "edge", "community"] or ["postmarketos", "master"] */
-          g_autofree gchar *repo = repo_parts[0];
+          g_autofree gchar *repo = g_strdup (repo_parts[0]);
           if (g_strv_length (repo_parts) == 3)
             {
+              g_free (repo);
               repo = g_strdup_printf ("%s %s", repo_parts[0], repo_parts[2]);
             }
 
-          g_autofree gchar *release = "";
+          g_autofree gchar *release = g_strdup ("");
           if (g_strv_length (repo_parts) >= 2)
             {
+              g_free (release);
               release = g_strdup_printf (" (release %s)", repo_parts[1]);
             }
           repo_displayname = g_strdup_printf (_ ("Remote repository %s%s"), repo, release);


### PR DESCRIPTION
I'm really sorry for this... I bumped into a segfault randomly running in pmOS, and turns out it was this mistake. I understand that right after a release this is annoying. I can add the patch here: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/28996 instead of releasing 0.9.1. 

On a side-note, testing these things manually on two distros is a huge pain. I should make writing some tests a priority. I had pushed it back due to the discussion in #17, but might  as well do it anyway...