### PR TITLE
Only updates apps for which we are the management plugin

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -400,6 +400,10 @@ gs_plugin_update (GsPlugin *plugin,
       app = gs_app_list_index (apps, i);
       priv->current_app = app;
 
+      /* We can only update apps we know of */
+      if (g_strcmp0 (gs_app_get_management_plugin (app), "apk") != 0)
+        continue;
+
       g_debug ("Updating app %s", gs_app_get_unique_id (app));
 
       gs_app_set_state (app, GS_APP_STATE_INSTALLING);


### PR DESCRIPTION
This should fix some problem where apk plugin was trying to update
an app owned by the fwupd plugin when doing a firmware update.

@DylanVanAssche, can you verify that this actually fixes your problem?