### PR TITLE
gs-plugin-apk: do not duplicate app source in "apk::name" metadata

### DIFF
--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -226,12 +226,12 @@ main (int argc, char **argv)
   xml = g_strdup ("<?xml version=\"1.0\"?>\n"
                   "<components version=\"0.9\">\n"
                   "  <component type=\"desktop\">\n"
-                  "    <id>a.desktop</id>\n"
-                  "    <name>a</name>\n"
-                  "    <pkgname>a</pkgname>\n"
+                  "    <id>apk-test-app.desktop</id>\n"
+                  "    <name>apk-test-app</name>\n"
+                  "    <pkgname>apk-test-app</pkgname>\n"
                   "  </component>\n"
                   "  <info>\n"
-                  "    <scope>user</scope>\n"
+                  "    <scope>system</scope>\n"
                   "  </info>\n"
                   "</components>\n");
   g_setenv ("GS_SELF_TEST_APPSTREAM_XML", xml, TRUE);

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -52,6 +52,7 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
   g_assert_cmpstr (gs_app_get_management_plugin (repo), ==, "apk");
 
   // Remove repository
+  g_object_unref (plugin_job);
   plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_REMOVE_REPO,
                                    "app", repo,
                                    NULL);
@@ -67,6 +68,7 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
   g_assert_cmpint (gs_app_get_state (repo), ==, GS_APP_STATE_AVAILABLE);
 
   // gs_plugin_install_repo (reinstall it, check it works)
+  g_object_unref (plugin_job);
   plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_INSTALL_REPO,
                                    "app", repo,
                                    NULL);
@@ -81,6 +83,7 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
 
   // Refresh repos.
   // TODO: Check logs!
+  g_object_unref (plugin_job);
   plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_REFRESH, NULL);
   rc = gs_plugin_loader_job_action (plugin_loader, plugin_job, NULL, &error);
   gs_test_flush_main_context ();
@@ -136,6 +139,7 @@ gs_plugins_apk_updates (GsPluginLoader *plugin_loader)
   // Execute update!
   foreign_app = gs_app_new ("foreign");
   gs_app_list_add (update_list, foreign_app); // No management plugin, should get ignored!
+  g_object_unref (plugin_job);
   plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_UPDATE,
                                    "list", update_list,
                                    NULL);

--- a/tests/test.py
+++ b/tests/test.py
@@ -41,8 +41,8 @@ class GsPluginApkTest (DBusTestCase):
             ('AddRepository', 's', '', ''),
             ('RemoveRepository', 's', '', ''),
             ('ListUpgradablePackages', '', 'a(ssssssttu)', 'ret = [' +
-             '("a", "0.2.0", "pkg a", "GPL", "0.1.0", "url", 50, 40, 4),' + # 4 = UPGRADABLE
-             '("b", "0.2.0", "pkg b", "GPL", "0.3.0", "url", 50, 40, 5),' + # 5 = DOWNGRADABLE
+             '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 4),' + # 4 = UPGRADABLE
+             '("b", "0.2.0", "system package", "GPL", "0.3.0", "url", 50, 40, 5),' + # 5 = DOWNGRADABLE
              ']'),
             ('UpgradePackage', 's', '', ''),
         ])

--- a/tests/test.py
+++ b/tests/test.py
@@ -45,6 +45,11 @@ class GsPluginApkTest (DBusTestCase):
              '("b", "0.2.0", "system package", "GPL", "0.3.0", "url", 50, 40, 5),' + # 5 = DOWNGRADABLE
              ']'),
             ('UpgradePackage', 's', '', ''),
+            # We only expect to refine the desktop app for now.
+            # Ideally, the state should be updated on the different DBus calls
+            ('GetPackageDetails', 's', '(ssssssttu)', 'ret = ' +
+             '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 2)' # 2 = AVAILABLE
+            ),
         ])
 
 


### PR DESCRIPTION
The duplication lead to inconsistent use accross the plugin and is
unnecessary. Each app managed by our plugin should have one and only one
source. Anything else is a bug in the metadata or in the distro packaging.


I haven't done extra security checks in the refine section of the plugin for two reasons:
 - It is not covered by tests (yet).
 - I have some dirty changes locally to fix and cleanup the refine. Might take a while to test and push them, but there's no reason to include partly and possibly broken changes here.