### PR TITLE
Refine fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ apk_dep = dependency('apk-polkit-client-1')
 glib_dep = dependency('glib-2.0', version: '>=2.60')
 gobject_dep = dependency('gobject-2.0')
 gio_dep = dependency('gio-2.0')
+appstream_dep = dependency('appstream')
 
 plugin_apk_lib = shared_library(
   'gs_plugin_apk',
@@ -21,7 +22,7 @@ plugin_apk_lib = shared_library(
   install : true,
   install_dir: plugin_install_dir,
   c_args : cargs,
-  dependencies : [ gnome_software_dep, apk_dep, glib_dep,  gobject_dep, gio_dep ],
+  dependencies : [ gnome_software_dep, apk_dep, glib_dep,  gobject_dep, gio_dep, appstream_dep],
 )
 
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
     meson_version: '>=0.58'
 )
 
-gnome_software_dep = dependency('gnome-software', version: '>=41.0')
+gnome_software_dep = dependency('gnome-software', version: '>=41.5')
 plugin_install_dir = gnome_software_dep.get_variable('plugindir')
 
 cargs = ['-DG_LOG_DOMAIN="GsPluginApk"', '-DI_KNOW_THE_GNOME_SOFTWARE_API_IS_SUBJECT_TO_CHANGE']

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -643,6 +643,7 @@ refine_apk_package (GsPlugin *plugin,
   GsPluginData *priv = gs_plugin_get_data (plugin);
   const gchar *source = gs_app_get_source_default (app);
 
+  g_debug ("Refining %s", gs_app_get_unique_id (app));
   if (!apk_polkit1_call_get_package_details_sync (priv->proxy, source, &apk_package, cancellable, &local_error))
     {
       g_dbus_error_strip_remote_error (local_error);
@@ -719,7 +720,10 @@ gs_plugin_refine (GsPlugin *plugin,
         }
 
       if (g_strcmp0 (gs_app_get_management_plugin (app), gs_plugin_get_name (plugin)) != 0)
-        continue;
+        {
+          g_debug ("Ignoring app %s, not owned by apk", gs_app_get_unique_id (app));
+          continue;
+        }
 
       sources = gs_app_get_sources (app);
       if (sources->len == 0)

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -508,7 +508,8 @@ set_app_metadata (GsPlugin *plugin, GsApp *app, ApkdPackage *package, GsPluginRe
     {
       gs_app_set_version (app, package->m_version);
     }
-  if (flags & GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN)
+  if (flags & GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN &&
+      gs_app_get_origin (app) == NULL)
     {
       gs_app_set_origin (app, "alpine");
     }
@@ -532,7 +533,8 @@ set_app_metadata (GsPlugin *plugin, GsApp *app, ApkdPackage *package, GsPluginRe
   if (flags & GS_PLUGIN_REFINE_FLAGS_DEFAULT)
     {
       gs_app_set_version (app, package->m_version);
-      gs_app_set_origin (app, "alpine");
+      if (gs_app_get_origin (app) == NULL)
+        gs_app_set_origin (app, "alpine");
       gs_app_set_summary (app, GS_APP_QUALITY_UNKNOWN, package->m_description);
       gs_app_set_size_download (app, package->m_size);
       gs_app_set_size_installed (app, package->m_installedSize);


### PR DESCRIPTION
So basically what the title says. Seems to work more cleanly in my system now (before was crashing on apps like pure-maps or emacs-nox, where the upstream AS fails to be generated).

Helps #14 
Helps #19 