### PR TITLE
ci: pull the head of the pull request in CI for testing

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -14,7 +14,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build
         run: meson build && ninja -C build


### PR DESCRIPTION
This is certified as insecure by GitHub[1], but at the same time
seems to be the only way I could find to make things work without
using GITHUB_TOKEN, which requires further setup for the ghcr.
Certainly, GitHub actions are not built for open-source developments
by individuals, but by companies that have things to hide[2][3].
Yes, with this kind of checkout, anybody could send a PR where they
modify the code, create some random scripts to be executed by meson
build and meson test, and likely steal the DOCKER_TOKEN or execute
random code in the builder. But I mean, is that really a problem?
Anybody can execute random code in public builders and if the token
has restricted enough permissions, yes, somebody could push or pull
the very specific image that we are using... Whose source is public
in this same repository! In worst case, if somebody would "exploit"
this "security hole", the accountability is warrantied by the fact
that a PR is needed.

[1]https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
[2]https://github.community/t/can-i-allow-prs-to-access-secrets-in-an-approved-environment/167745
[3]https://github.community/t/make-secrets-available-to-builds-of-forks/16166


F**** github. If after merging this, #35 does not build successfully the latest code in the repo, then I give up and will rather move this to gitlab