### PR TITLE
Port to GNOME Software 42

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "" >> /etc/apk/repositories \
 RUN apk add --no-cache meson gnome-software-dev apk-polkit-rs-dev build-base \
     curl gdk-pixbuf-dev libxmlb-dev glib-dev gtk4.0-dev libadwaita-dev \
     json-glib-dev libsoup3-dev gspell-dev polkit-dev libgudev-dev appstream-dev \
-    desktop-file-utils gsettings-desktop-schemas-dev
+    desktop-file-utils gsettings-desktop-schemas-dev dbus
 RUN curl -L -O https://gitlab.gnome.org/GNOME/gnome-software/-/archive/${BRANCH}/gnome-software-${BRANCH}.tar.gz \
     && tar xf gnome-software-${BRANCH}.tar.gz \
     && cd gnome-software-${BRANCH} \

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,12 +1,16 @@
-FROM docker.io/alpine:latest
+FROM ghcr.io/distroless/alpine-base:latest
 
+ENV BRANCH=gnome-42
+# distroless/alpine-base only has main by default
+RUN echo "" >> /etc/apk/repositories \
+    && echo https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
 RUN apk add --no-cache meson gnome-software-dev apk-polkit-rs-dev build-base \
-    curl gdk-pixbuf-dev libxmlb-dev glib-dev gtk+3.0-dev libhandy1-dev \
-    json-glib-dev libsoup-dev gspell-dev polkit-dev libgudev-dev appstream-dev \
+    curl gdk-pixbuf-dev libxmlb-dev glib-dev gtk4.0-dev libadwaita-dev \
+    json-glib-dev libsoup3-dev gspell-dev polkit-dev libgudev-dev appstream-dev \
     desktop-file-utils gsettings-desktop-schemas-dev
-RUN curl -L -O https://gitlab.gnome.org/pabloyoyoista/gnome-software/-/archive/alpine-patch/gnome-software-alpine-patch.tar.gz \
-    && tar xf gnome-software-alpine-patch.tar.gz \
-    && cd gnome-software-alpine-patch \
+RUN curl -L -O https://gitlab.gnome.org/GNOME/gnome-software/-/archive/${BRANCH}/gnome-software-${BRANCH}.tar.gz \
+    && tar xf gnome-software-${BRANCH}.tar.gz \
+    && cd gnome-software-${BRANCH} \
     && meson \
        --prefix /usr \
        -Dvalgrind=false \

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: cogitri/gnome-software-plugin-apk-ci
-  VERSION: 41
+  VERSION: 42
 
 jobs:
   build-test-and-push-image:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       packages: read
     container:
-      image: ghcr.io/cogitri/gnome-software-plugin-apk-ci:41
+      image: ghcr.io/cogitri/gnome-software-plugin-apk-ci:42
       credentials:
         username: cogitri
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
     meson_version: '>=0.58'
 )
 
-gnome_software_dep = dependency('gnome-software', version: '>=41.5')
+gnome_software_dep = dependency('gnome-software', version: '>=42.0')
 plugin_install_dir = gnome_software_dep.get_variable('plugindir')
 
 cargs = ['-DG_LOG_DOMAIN="GsPluginApk"', '-DI_KNOW_THE_GNOME_SOFTWARE_API_IS_SUBJECT_TO_CHANGE']

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -530,17 +530,9 @@ set_app_metadata (GsPlugin *plugin, GsApp *app, ApkdPackage *package, GsPluginRe
     {
       gs_app_set_license (app, GS_APP_QUALITY_UNKNOWN, package->m_license);
     }
-  if (flags & GS_PLUGIN_REFINE_FLAGS_DEFAULT)
-    {
-      gs_app_set_version (app, package->m_version);
-      if (gs_app_get_origin (app) == NULL)
-        gs_app_set_origin (app, "alpine");
-      gs_app_set_summary (app, GS_APP_QUALITY_UNKNOWN, package->m_description);
-      gs_app_set_size_download (app, package->m_size);
-      gs_app_set_size_installed (app, package->m_installedSize);
-      gs_app_set_url (app, AS_URL_KIND_HOMEPAGE, package->m_url);
-      gs_app_set_license (app, GS_APP_QUALITY_UNKNOWN, package->m_license);
-    }
+  if (flags & GS_PLUGIN_REFINE_FLAGS_NONE)
+    return;
+
   g_debug ("State for pkg %s: %u", gs_app_get_unique_id (app), package->m_packageState);
   /* FIXME: Currently apk-rs-polkit only returns states Available and Installed
    * regardless of whether the packages are in a different state like upgraded.
@@ -746,8 +738,7 @@ gs_plugin_refine (GsPlugin *plugin,
            GS_PLUGIN_REFINE_FLAGS_REQUIRE_SETUP_ACTION |
            GS_PLUGIN_REFINE_FLAGS_REQUIRE_SIZE |
            GS_PLUGIN_REFINE_FLAGS_REQUIRE_URL |
-           GS_PLUGIN_REFINE_FLAGS_REQUIRE_LICENSE |
-           GS_PLUGIN_REFINE_FLAGS_DEFAULT))
+           GS_PLUGIN_REFINE_FLAGS_REQUIRE_LICENSE))
         {
           if (!refine_apk_package (plugin, app, flags, cancellable, error))
             return FALSE;

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -264,7 +264,7 @@ gs_plugin_setup (GsPlugin *plugin, GCancellable *cancellable, GError **error)
 
 gboolean
 gs_plugin_refresh (GsPlugin *plugin,
-                   guint cache_age,
+                   guint64 cache_age_secs,
                    GCancellable *cancellable,
                    GError **error)
 {

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -50,7 +50,7 @@ typedef struct
  * g_variant_to_apkd_package:
  * @value_tuple: a GVariant, as received from apk_polkit1_call*
  *
- * Convenience finction which conerts a GVariant we get pack from our DBus
+ * Convenience function which converts a GVariant pack we get from our DBus
  * proxy to a ApkdPackage
  **/
 static ApkdPackage

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "gs-plugin-apk.h"
 #include <apk-polkit-1/apk-polkit-client.h>
 #include <appstream.h>
 #include <gnome-software.h>
 #include <libintl.h>
 #include <locale.h>
-#include "gs-plugin-apk.h"
 #define _(string) gettext (string)
 
 /**
@@ -236,22 +236,22 @@ gs_plugin_apk_init (GsPluginApk *self)
 }
 
 static gboolean
-gs_plugin_apk_setup_finish (GsPlugin      *plugin,
-                            GAsyncResult  *result,
-                            GError       **error)
+gs_plugin_apk_setup_finish (GsPlugin *plugin,
+                            GAsyncResult *result,
+                            GError **error)
 {
   return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void
-gs_plugin_apk_setup_async (GsPlugin            *plugin,
-                           GCancellable        *cancellable,
-                           GAsyncReadyCallback  callback,
-                           gpointer             user_data)
+gs_plugin_apk_setup_async (GsPlugin *plugin,
+                           GCancellable *cancellable,
+                           GAsyncReadyCallback callback,
+                           gpointer user_data)
 {
   GsPluginApk *self = GS_PLUGIN_APK (plugin);
   g_autoptr (GError) error = NULL;
-  g_autoptr(GTask) task = NULL;
+  g_autoptr (GTask) task = NULL;
 
   task = g_task_new (plugin, cancellable, callback, user_data);
   g_task_set_source_tag (task, gs_plugin_apk_setup_async);
@@ -281,20 +281,20 @@ gs_plugin_apk_setup_async (GsPlugin            *plugin,
 }
 
 static gboolean
-gs_plugin_apk_refresh_metadata_finish (GsPlugin      *plugin,
-                                       GAsyncResult  *result,
-                                       GError       **error)
+gs_plugin_apk_refresh_metadata_finish (GsPlugin *plugin,
+                                       GAsyncResult *result,
+                                       GError **error)
 {
   return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void
-gs_plugin_apk_refresh_metadata_async (GsPlugin                     *plugin,
-                                      guint64                       cache_age_secs,
-                                      GsPluginRefreshMetadataFlags  flags,
-                                      GCancellable                 *cancellable,
-                                      GAsyncReadyCallback           callback,
-                                      gpointer                      user_data)
+gs_plugin_apk_refresh_metadata_async (GsPlugin *plugin,
+                                      guint64 cache_age_secs,
+                                      GsPluginRefreshMetadataFlags flags,
+                                      GCancellable *cancellable,
+                                      GAsyncReadyCallback callback,
+                                      gpointer user_data)
 {
   GsPluginApk *self = GS_PLUGIN_APK (plugin);
   g_autoptr (GTask) task = NULL;
@@ -685,20 +685,20 @@ refine_apk_package (GsPlugin *plugin,
 }
 
 static gboolean
-gs_plugin_apk_refine_finish (GsPlugin      *plugin,
-                             GAsyncResult  *result,
-                             GError       **error)
+gs_plugin_apk_refine_finish (GsPlugin *plugin,
+                             GAsyncResult *result,
+                             GError **error)
 {
   return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void
-gs_plugin_apk_refine_async (GsPlugin            *plugin,
-                            GsAppList           *list,
-                            GsPluginRefineFlags  flags,
-                            GCancellable        *cancellable,
-                            GAsyncReadyCallback  callback,
-                            gpointer             user_data)
+gs_plugin_apk_refine_async (GsPlugin *plugin,
+                            GsAppList *list,
+                            GsPluginRefineFlags flags,
+                            GCancellable *cancellable,
+                            GAsyncReadyCallback callback,
+                            gpointer user_data)
 {
   g_autoptr (GTask) task = NULL;
   g_autoptr (GError) error = NULL;
@@ -753,10 +753,10 @@ gs_plugin_apk_refine_async (GsPlugin            *plugin,
               if (!fix_app_missing_appstream (plugin, app, cancellable))
                 {
                   if (g_cancellable_is_cancelled (cancellable))
-		    {
+                    {
                       g_task_return_boolean (task, TRUE);
                       return;
-		    }
+                    }
                   else
                     continue;
                 }
@@ -796,8 +796,8 @@ gs_plugin_apk_refine_async (GsPlugin            *plugin,
           if (!refine_apk_package (plugin, app, flags, cancellable, &error))
             {
               g_task_return_error (task, error);
-	      return;
-	  }
+              return;
+            }
         }
     }
 

--- a/src/gs-plugin-apk/gs-plugin-apk.h
+++ b/src/gs-plugin-apk/gs-plugin-apk.h
@@ -1,0 +1,19 @@
+ /* 
+  * Copyright (C) 2022 Dylan Van Assche <me@dylanvanassche.be>
+  *
+  * SPDX-License-Identifier: GPL-2.0+
+  */
+
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+#include <gnome-software.h>
+
+G_BEGIN_DECLS
+
+#define GS_TYPE_PLUGIN_APK (gs_plugin_apk_get_type ())
+
+G_DECLARE_FINAL_TYPE (GsPluginApk, gs_plugin_apk, GS, PLUGIN_APK, GsPlugin)
+
+G_END_DECLS

--- a/src/gs-plugin-apk/gs-plugin-apk.h
+++ b/src/gs-plugin-apk/gs-plugin-apk.h
@@ -1,13 +1,13 @@
- /* 
-  * Copyright (C) 2022 Dylan Van Assche <me@dylanvanassche.be>
-  *
-  * SPDX-License-Identifier: GPL-2.0+
-  */
+/*
+ * Copyright (C) 2022 Dylan Van Assche <me@dylanvanassche.be>
+ *
+ * SPDX-License-Identifier: GPL-2.0+
+ */
 
 #pragma once
 
-#include <glib.h>
 #include <glib-object.h>
+#include <glib.h>
 #include <gnome-software.h>
 
 G_BEGIN_DECLS

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -88,7 +88,7 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
   // Refresh repos.
   // TODO: Check logs!
   g_object_unref (plugin_job);
-  plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_REFRESH, NULL);
+  plugin_job = gs_plugin_job_refresh_metadata_new (G_MAXUINT64, GS_PLUGIN_REFRESH_METADATA_FLAGS_NONE);
   rc = gs_plugin_loader_job_action (plugin_loader, plugin_job, NULL, &error);
   gs_test_flush_main_context ();
   g_assert_no_error (error);

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -280,7 +280,7 @@ main (int argc, char **argv)
   gs_plugin_loader_add_location (plugin_loader, LOCALPLUGINDIR);
   gs_plugin_loader_add_location (plugin_loader, SYSTEMPLUGINDIR);
   ret = gs_plugin_loader_setup (plugin_loader,
-                                (gchar **) allowlist,
+                                allowlist,
                                 NULL,
                                 NULL,
                                 &error);

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -26,6 +26,7 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
   g_autoptr (GError) error = NULL;
   g_autoptr (GsPluginJob) plugin_job = NULL;
   g_autoptr (GsAppList) list = NULL;
+  g_autoptr (GsPlugin) plugin = NULL;
   GsApp *repo = NULL;
   gboolean rc;
 
@@ -39,17 +40,20 @@ gs_plugins_apk_repo_actions (GsPluginLoader *plugin_loader)
   // Verify correctness of result. TODO: for loop and check app name
   g_assert_cmpint (gs_app_list_length (list), ==, 3);
   repo = gs_app_list_index (list, 0);
+  plugin = GS_PLUGIN (gs_app_dup_management_plugin (repo));
   g_assert_cmpint (gs_app_get_kind (repo), ==, AS_COMPONENT_KIND_REPOSITORY);
   g_assert_cmpint (gs_app_get_state (repo), ==, GS_APP_STATE_INSTALLED);
-  g_assert_cmpstr (gs_app_get_management_plugin (repo), ==, "apk");
+  g_assert_cmpstr (gs_plugin_get_name (plugin), ==, "apk");
   repo = gs_app_list_index (list, 1);
+  plugin = GS_PLUGIN (gs_app_dup_management_plugin (repo));
   g_assert_cmpint (gs_app_get_kind (repo), ==, AS_COMPONENT_KIND_REPOSITORY);
   g_assert_cmpint (gs_app_get_state (repo), ==, GS_APP_STATE_AVAILABLE);
-  g_assert_cmpstr (gs_app_get_management_plugin (repo), ==, "apk");
+  g_assert_cmpstr (gs_plugin_get_name (plugin), ==, "apk");
   repo = gs_app_list_index (list, 2);
+  plugin = GS_PLUGIN (gs_app_dup_management_plugin (repo));
   g_assert_cmpint (gs_app_get_kind (repo), ==, AS_COMPONENT_KIND_REPOSITORY);
   g_assert_cmpint (gs_app_get_state (repo), ==, GS_APP_STATE_INSTALLED);
-  g_assert_cmpstr (gs_app_get_management_plugin (repo), ==, "apk");
+  g_assert_cmpstr (gs_plugin_get_name (plugin), ==, "apk");
 
   // Remove repository
   g_object_unref (plugin_job);
@@ -167,6 +171,7 @@ gs_plugins_apk_app_install_remove (GsPluginLoader *plugin_loader)
   g_autoptr (GError) error = NULL;
   g_autoptr (GsPluginJob) plugin_job = NULL;
   g_autoptr (GsApp) app = NULL;
+  g_autoptr (GsPlugin) plugin = NULL;
   gboolean rc;
 
   // Search for a non-installed app
@@ -179,10 +184,11 @@ gs_plugins_apk_app_install_remove (GsPluginLoader *plugin_loader)
   gs_test_flush_main_context ();
   g_assert_no_error (error);
   g_assert (app != NULL);
+  plugin = GS_PLUGIN (gs_app_dup_management_plugin (app));
 
   // make sure we got the correct app and is managed by us
   g_assert_cmpstr (gs_app_get_id (app), ==, "apk-test-app.desktop");
-  g_assert_cmpstr (gs_app_get_management_plugin (app), ==, "apk");
+  g_assert_cmpstr (gs_plugin_get_name (plugin), ==, "apk");
   g_assert_cmpint (gs_app_get_kind (app), ==, AS_COMPONENT_KIND_DESKTOP_APP);
   g_assert_cmpint (gs_app_get_scope (app), ==, AS_COMPONENT_SCOPE_SYSTEM);
   g_assert_cmpint (gs_app_get_state (app), ==, GS_APP_STATE_AVAILABLE);


### PR DESCRIPTION
Ports the plugin to the new API in GNOME Software 42:

- [x] Plugins are now subclasses: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1042
- [x] Rework get and set management plugin: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1106
- [x] Async plugin setup and shutdown: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1114
- [x] Changed refine flags DEFAULT and USE_HISTORY: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1132
- [x] Rework of refine to make it asynchronous: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1134
- [x] Rework of add_installed to make it asynchronous: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1169
- [x] Change cache to guint64 and rename for better readability: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1219
- [x] Rework of refresh to make it asynchronous: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1259

See individual commits for a detailed description of the changes.
Not tested at all, will comment here when done.

Fixes #17 