### PR TITLE
Testing timeout

### DIFF
--- a/tests/apkpolkit1.py
+++ b/tests/apkpolkit1.py
@@ -1,0 +1,54 @@
+# apkpolkit1.py -- apkPolkit1 mock template
+#
+# Copyright (C) 2022 Pablo Correa Gomez <ablocorrea@hotmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+import dbus
+import dbusmock
+
+import time
+
+BUS_NAME   = 'dev.Cogitri.apkPolkit1'
+MAIN_OBJ   = '/dev/Cogitri/apkPolkit1'
+MAIN_IFACE = 'dev.Cogitri.apkPolkit1'
+SYSTEM_BUS = True
+
+def load(mock, parameters):
+    repos = [
+        (True, "a", "https://alpine.org/alpine/edge/main"),
+        (False, "b", "https://pmos.org/pmos/master"),
+        (True, "c", "/home/data/foo/bar/baz"),
+    ]
+    mock.repos = repos
+
+    mock.AddMethods(MAIN_IFACE, [
+        ('UpdateRepositories', '', '', ''),
+        ('AddRepository', 's', '', ''),
+        ('RemoveRepository', 's', '', ''),
+        ('ListUpgradablePackages', '', 'a(ssssssttu)', 'ret = [' +
+         '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 4),' + # 4 = UPGRADABLE
+         '("b", "0.2.0", "system package", "GPL", "0.3.0", "url", 50, 40, 5),' + # 5 = DOWNGRADABLE
+         ']'),
+        ('UpgradePackage', 's', '', ''),
+        # We only expect to refine the desktop app for now.
+        # Ideally, the state should be updated on the different DBus calls
+        ('GetPackageDetails', 's', '(ssssssttu)', 'ret = ' +
+         '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 2)' # 2 = AVAILABLE
+        ),
+    ])
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='')
+def AddPackage(self, pkg_name):
+    if (pkg_name == "slow"):
+        time.sleep(10)
+
+@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='')
+def DeletePackage(self, pkg_name):
+    if (pkg_name == "slow"):
+        time.sleep(10)
+
+@dbus.service.method(MAIN_IFACE, in_signature='', out_signature='a(bss)')
+def ListRepositories(self):
+    return self.repos

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -238,6 +238,8 @@ main (int argc, char **argv)
    * Might be useful at some point though */
   g_assert_true (g_settings_set_strv (settings, "external-appstream-urls", NULL));
 
+  g_setenv ("GS_XMLB_VERBOSE", "1", TRUE);
+
   /* Adapted from upstream dummy/gs-self-test.c */
   xml = g_strdup ("<?xml version=\"1.0\"?>\n"
                   "<components version=\"0.9\">\n"

--- a/tests/gs-self-test.c
+++ b/tests/gs-self-test.c
@@ -242,10 +242,11 @@ main (int argc, char **argv)
 
   /* Adapted from upstream dummy/gs-self-test.c */
   xml = g_strdup ("<?xml version=\"1.0\"?>\n"
-                  "<components version=\"0.9\">\n"
+                  "<components origin=\"alpine-test\" version=\"0.9\">\n"
                   "  <component type=\"desktop\">\n"
                   "    <id>apk-test-app.desktop</id>\n"
                   "    <name>apk-test-app</name>\n"
+                  "    <summary>Alpine Package Keeper test app</summary>\n"
                   "    <pkgname>apk-test-app</pkgname>\n"
                   "  </component>\n"
                   "  <info>\n"

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,48 +15,18 @@ class GsPluginApkTest (DBusTestCase):
     @classmethod
     def setUpClass(klass):
         klass.start_system_bus()
-        klass.dbus_con = klass.get_dbus(system_bus=True)
 
     def setUp(self):
-        self.log = open(os.getenv('DBUS_TEST_LOG'), "w")
-        self.p_mock = self.spawn_server('dev.Cogitri.apkPolkit1',
-                                        '/dev/Cogitri/apkPolkit1',
-                                        'dev.Cogitri.apkPolkit1',
-                                        system_bus=True,
-                                        stdout=self.log)
-
-        self.apk_polkit_mock = dbus.Interface(self.dbus_con.
-                                              get_object('dev.Cogitri.apkPolkit1',
-                                                         '/dev/Cogitri/apkPolkit1'),
-                                              MOCK_IFACE)
-
-        self.apk_polkit_mock.AddMethods('', [
-            ('AddPackage', 's', '', ''),
-            ('DeletePackage', 's', '', ''),
-            ('ListRepositories', '', 'a(bss)', 'ret = [' +
-             '(True, "a", "https://alpine.org/alpine/edge/main"),' +
-             '(False, "b", "https://pmos.org/pmos/master"),' +
-             '(True, "c", "/home/data/foo/bar/baz"),' + ']'),
-            ('UpdateRepositories', '', '', ''),
-            ('AddRepository', 's', '', ''),
-            ('RemoveRepository', 's', '', ''),
-            ('ListUpgradablePackages', '', 'a(ssssssttu)', 'ret = [' +
-             '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 4),' + # 4 = UPGRADABLE
-             '("b", "0.2.0", "system package", "GPL", "0.3.0", "url", 50, 40, 5),' + # 5 = DOWNGRADABLE
-             ']'),
-            ('UpgradePackage', 's', '', ''),
-            # We only expect to refine the desktop app for now.
-            # Ideally, the state should be updated on the different DBus calls
-            ('GetPackageDetails', 's', '(ssssssttu)', 'ret = ' +
-             '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 2)' # 2 = AVAILABLE
-            ),
-        ])
-
+        self.log = None
+        if os.getenv('DBUS_TEST_LOG') is not None:
+            self.log = open(os.getenv('DBUS_TEST_LOG'), "w")
+        template = os.path.join(os.getenv('G_TEST_SRCDIR'), 'apkpolkit1.py')
+        (self.p_mock, _) = self.spawn_server_template(template,
+                                                      stdout=self.log)
 
     def tearDown(self):
-        self.log.close()
-        self.p_mock.terminate()
-        self.p_mock.wait()
+        if self.log is not None:
+            self.log.close()
 
     def test_apk(self):
         builddir = os.getenv('G_TEST_BUILDDIR')


### PR DESCRIPTION
This is an attempt to try to reproduce in CI the issues I have found while testing #41. Unfortunately, there is some quite weird behavior: 
 * Although the timeout is set to two seconds, the synchronous 10 seconds operation does not get cancelled and executes until completion.
 * Even if the execution time was greater than the timeout, the exit is still successful, instead of returning the TIMEOUT error.

This seems like some bug in the dbusmock code, which can only handle sync operations. However, it might be exactly the reason why it is failing in the real-world. As far as I understand, all the ApkPolkit1 operations are currently synchronous (none making use of `async` in rust). Therefore, we cannot abort them and we might be seeing a crash in 42 if it removes things after the timeout which are still in use. Maybe one solution would be for us to check the cancellable on any for loop that involves a dbus call. But to be honest, I am quite confused about this problem in general.