### PR TITLE
gs-plugin-apk: use GetPackagesDetails to speed-up refine

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -50,6 +50,9 @@ class GsPluginApkTest (DBusTestCase):
             ('GetPackageDetails', 's', '(ssssssttu)', 'ret = ' +
              '("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 2)' # 2 = AVAILABLE
             ),
+            ('GetPackagesDetails', 'as', 'a(ssssssttu)', 'ret = ' +
+             '[("apk-test-app", "0.2.0", "desktop app", "GPL", "0.1.0", "url", 50, 40, 2),]' # 2 = AVAILABLE
+            ),
         ])
 
 


### PR DESCRIPTION
This makes the refine mostly instantaneous by putting together
all the DBus calls into a single one. It requires a new method
in the apk-polkit-rs DBus service:
https://gitlab.alpinelinux.org/Cogitri/apk-polkit-rs/-/merge_requests/29

Closes #44. The async operations are not needed as long as we are fast enough, since the callbacks are already async and we won't block the main thread.

This makes #49 even more obvious, but suddenly the app is extremely fast. Updates and available apps are loaded mostly instantaneously, which is absolutely amazing!