### PR TITLE
Leak fixes

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -221,7 +221,7 @@ apk_progress_signal_connect_callback (GDBusProxy *proxy,
   gs_plugin_status_update ((GsPlugin *) user_data, self->current_app, plugin_status);
 }
 
-void
+static void
 gs_plugin_apk_init (GsPluginApk *self)
 {
   GsPlugin *plugin = GS_PLUGIN (self);
@@ -231,6 +231,18 @@ gs_plugin_apk_init (GsPluginApk *self)
   /* We want to get packages from appstream and refine them */
   gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "appstream");
   self->current_app = NULL;
+  self->proxy = NULL;
+}
+
+static void
+gs_plugin_apk_dispose (GObject *object)
+{
+  GsPluginApk *self = GS_PLUGIN_APK (object);
+
+  g_clear_object (&self->current_app);
+  g_clear_object (&self->proxy);
+
+  G_OBJECT_CLASS (gs_plugin_apk_parent_class)->dispose (object);
 }
 
 static gboolean
@@ -983,7 +995,10 @@ gs_plugin_remove_repo (GsPlugin *plugin,
 static void
 gs_plugin_apk_class_init (GsPluginApkClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GsPluginClass *plugin_class = GS_PLUGIN_CLASS (klass);
+
+  object_class->dispose = gs_plugin_apk_dispose;
 
   plugin_class->setup_async = gs_plugin_apk_setup_async;
   plugin_class->setup_finish = gs_plugin_apk_setup_finish;

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -111,7 +111,9 @@ apk_to_app_state (ApkPackageState state)
 static GsApp *
 apk_package_to_app (GsPlugin *plugin, ApkdPackage *pkg)
 {
-  GsApp *app = gs_plugin_cache_lookup (plugin, g_strdup_printf ("%s-%s", pkg->m_name, pkg->m_version));
+  g_autofree gchar *cache_name = NULL;
+  cache_name = g_strdup_printf ("%s-%s", pkg->m_name, pkg->m_version);
+  GsApp *app = gs_plugin_cache_lookup (plugin, cache_name);
   if (app != NULL)
     {
       return app;
@@ -145,7 +147,7 @@ apk_package_to_app (GsPlugin *plugin, ApkdPackage *pkg)
     {
       gs_app_set_version (app, pkg->m_version);
     }
-  gs_plugin_cache_add (plugin, g_strdup_printf ("%s-%s", pkg->m_name, pkg->m_version), app);
+  gs_plugin_cache_add (plugin, cache_name, app);
 
   return app;
 }


### PR DESCRIPTION
```
gs-plugin-apk: fix leak in g_variant_to_apkd_package

The g_variant_get_child_value calls create a new GVariant which
is expected to be freed[1]. Right now, by piping the result, such
GVariant is directly leaked. Instead, use g_variant_get with the
signature of the variant. Use "&s" for every string, to avoid
generating a copy and getting ownership[2]. This way, all the data
actually resides in the value_tuple parameter.

[1]https://docs.gtk.org/glib/method.Variant.get_child_value.html#return-value
[2]https://docs.gtk.org/glib/gvariant-format-strings.html#pointers
```

```
gs-plugin-apk: do not leak cache name

g_strdup_printf transfers ownership, which C does not know
how to automatically free unless instructed to.

Fixes #14
```

```
gs-plugin-apk: add dispose method

This cleans up if the plugin is ever unloaded or destroyed.

Fixes #43
```

Fixes #14 
Fixes #43 