### PR TITLE
Make DBus calls in async operations async

### DIFF
--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -512,7 +512,15 @@ gs_plugin_update (GsPlugin *plugin,
           GsApp *app = gs_app_list_index (update_list, i);
           gs_app_set_state_recover (app);
         }
-      /*gs_app_set_state_recover (app); TODO: Fix this! */
+
+      /* Roll-back apps from the original list with a quirk */
+      for (int i = 0; i < gs_app_list_length (list); i++)
+        {
+          GsApp *app = gs_app_list_index (list, i);
+          if (gs_app_has_quirk (app, GS_APP_QUIRK_IS_PROXY))
+            gs_app_set_state_recover (app);
+        }
+
       return FALSE;
     }
 

--- a/src/gs-plugin-apk/gs-plugin-apk.c
+++ b/src/gs-plugin-apk/gs-plugin-apk.c
@@ -256,18 +256,15 @@ gs_plugin_apk_refresh_metadata_async (GsPlugin *plugin,
   GsPluginApk *self = GS_PLUGIN_APK (plugin);
   g_autoptr (GTask) task = NULL;
   g_autoptr (GError) local_error = NULL;
-  g_autoptr (GsApp) app_dl = gs_app_new (gs_plugin_get_name (plugin));
 
   task = g_task_new (plugin, cancellable, callback, user_data);
   g_task_set_source_tag (task, gs_plugin_apk_refresh_metadata_async);
 
   g_debug ("Refreshing repositories");
 
-  gs_app_set_summary_missing (app_dl, _ ("Getting apk repository indexes…"));
-  gs_plugin_status_update (plugin, app_dl, GS_PLUGIN_STATUS_DOWNLOADING);
+  gs_plugin_status_update (plugin, NULL, GS_PLUGIN_STATUS_DOWNLOADING);
   if (apk_polkit2_call_update_repositories_sync (self->proxy, cancellable, &local_error))
     {
-      gs_app_set_progress (app_dl, 100);
       gs_plugin_updates_changed (plugin);
       g_task_return_boolean (task, TRUE);
       return;
@@ -288,11 +285,9 @@ gs_plugin_add_updates (GsPlugin *plugin,
   GsPluginApk *self = GS_PLUGIN_APK (plugin);
   g_autoptr (GVariant) upgradable_packages = NULL;
   g_autoptr (GError) local_error = NULL;
-  g_autoptr (GsApp) app_dl = gs_app_new (gs_plugin_get_name (plugin));
 
-  g_debug ("Adding updates");
   /* I believe we have to invalidate the cache here! */
-  gs_app_set_progress (app_dl, GS_APP_PROGRESS_UNKNOWN);
+  g_debug ("Adding updates");
 
   if (!apk_polkit2_call_list_upgradable_packages_sync (self->proxy,
                                                        APK_POLKIT_CLIENT_DETAILS_FLAGS_ALL,
@@ -452,11 +447,11 @@ gs_plugin_update (GsPlugin *plugin,
 {
   GsPluginApk *self = GS_PLUGIN_APK (plugin);
   g_autoptr (GError) local_error = NULL;
-  g_autoptr (GsApp) app_dl = gs_app_new (gs_plugin_get_name (plugin));
   g_autoptr (GsAppList) update_list = gs_app_list_new ();
   g_autofree const gchar **source_array = NULL;
 
-  gs_app_set_progress (app_dl, GS_APP_PROGRESS_UNKNOWN);
+  /* update UI as this might take some time */
+  gs_plugin_status_update (plugin, NULL, GS_PLUGIN_STATUS_WAITING);
 
   gs_plugin_apk_prepare_update (plugin, list, update_list);
 

--- a/tests/apkpolkit2.py
+++ b/tests/apkpolkit2.py
@@ -51,7 +51,7 @@ def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [
         ('AddRepository', 's', '', ''),
         ('RemoveRepository', 's', '', ''),
-        ('UpdateRepositories', '', '', ''),
+        ('UpdateRepositories', '', '', 'time.sleep(2)'),
     ])
 
 


### PR DESCRIPTION
Async operations run in the main context. Therefore, long blocks in DBus calls can (and do) easily freeze the UI. Fix this by using async DBus calls.

Fixes #44 

Add a commit that also fixes #57  